### PR TITLE
chore(gradle) : replace deprecated keyword

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -19,6 +18,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.1'
-    compile 'testfairy:testfairy-android-sdk:1.8.3'
+    api 'com.facebook.react:react-native:0.20.1'
+    api 'testfairy:testfairy-android-sdk:1.8.3'
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "react-native-testfairy",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "TestFairy for React Native",
-  "author": "Gil Megidish",
+  "author": "testfairy",
   "main": "./index.js",
   "scripts": {
     "test": "echo \"Warn: no test specified. Skipping.\" && exit 0"
@@ -18,11 +18,9 @@
     "ios",
     "android"
   ],
-  "author": "testfairy",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/testfairy/react-native-testfairy"
   },
   "homepage": "https://github.com/testfairy/react-native-testfairy#readme"
 }
-


### PR DESCRIPTION
- Omit buildToolsVersion to avoid warning on build logs
- Update dependencies compile to use new api token to match [Link](http://d.android.com/r/tools/update-dependency-configurations.html)