### PR TITLE
Include only Testfairy's dependencies in maven definition

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,12 @@ dependencies {
 
 class TestFairyRepositoryPlugin implements Plugin<Gradle> {
     def configRepositories = { ->
-        maven { url "https://maven.testfairy.com" }
+        maven {
+            url "https://maven.testfairy.com"
+            content {
+                includeGroup "com.testfairy"
+            }
+        }
     }
 
     void apply(Object gradle) {


### PR DESCRIPTION
For some reason in our project we started getting this error:

```
Could not resolve com.facebook.soloader:soloader:0.9.0+.
 Failed to list versions for com.facebook.soloader:soloader.
 Unable to load Maven meta-data from https://maven.testfairy.com/com/facebook/soloader/soloader/maven-metadata.xml.
 Could not get resource 'https://maven.testfairy.com/com/facebook/soloader/soloader/maven-metadata.xml'.
 Could not GET 'https://maven.testfairy.com/com/facebook/soloader/soloader/maven-metadata.xml'. Received status code 403 from server: Forbidden
 ```

When adding the code proposed in this PR the error went away.