### PR TITLE
fix: use React-Core in the podspec

### DIFF
--- a/React-TestFairy.podspec
+++ b/React-TestFairy.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{xcodeproj}", "ios/*.{h,m}"
   s.requires_arc = true
   s.frameworks = "UIKit", "CoreMedia", "CoreMotion", "AVFoundation", "AVFoundation", "OpenGLES", "SystemConfiguration"
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "TestFairy", "1.30.2"
 end


### PR DESCRIPTION
This PR updates the iOS podspec definition to use the recommended "React-Core" dependency instead of "React".